### PR TITLE
Adjust error message for to long/to short function.

### DIFF
--- a/bin/hpw.js
+++ b/bin/hpw.js
@@ -74,8 +74,11 @@ const checkTarget = async (name, target, test) => {
   const msgLines = concolor`Lines: ${lines}(b,white)`;
   console.log(msgTarget + msgLength + msgLines);
   const [minLength, maxLength] = test.length || [];
-  if (targetLength > maxLength) throw new Error('Solution is too long: ' +
-    `no more than ${maxLength} characters expected.`);
+  if (targetLength > maxLength) {
+    throw new Error(
+      `Solution is too long: no more than ${maxLength} characters expected.`
+    );
+  }
   if (targetLength < minLength) throw new Error('Solution is too short: ' +
     `at least ${minLength} characters expected.`);
   let casesResult = 'No test cases';

--- a/bin/hpw.js
+++ b/bin/hpw.js
@@ -79,8 +79,11 @@ const checkTarget = async (name, target, test) => {
       `Solution is too long: no more than ${maxLength} characters expected.`
     );
   }
-  if (targetLength < minLength) throw new Error('Solution is too short: ' +
-    `at least ${minLength} characters expected.`);
+  if (targetLength < minLength) {
+    throw new Error(
+      `Solution is too short: at least ${minLength} characters expected.`
+    );
+  }
   let casesResult = 'No test cases';
   if (test.cases) {
     for (const callCase of test.cases) {

--- a/bin/hpw.js
+++ b/bin/hpw.js
@@ -74,8 +74,10 @@ const checkTarget = async (name, target, test) => {
   const msgLines = concolor`Lines: ${lines}(b,white)`;
   console.log(msgTarget + msgLength + msgLines);
   const [minLength, maxLength] = test.length || [];
-  if (targetLength > maxLength) throw new Error('Solution is too long');
-  if (targetLength < minLength) throw new Error('Solution is too short');
+  if (targetLength > maxLength) throw new Error('Solution is too long: ' +
+    `no more than ${maxLength} characters expected.`);
+  if (targetLength < minLength) throw new Error('Solution is too short: ' +
+    `at least ${minLength} characters expected.`);
   let casesResult = 'No test cases';
   if (test.cases) {
     for (const callCase of test.cases) {


### PR DESCRIPTION
Display expected min/max function length.

Example output:

```sh
Target: powerOfThree, Length: 33, Lines: 1
Error: Solution is too long: no more than 29 characters expected.
```